### PR TITLE
A few corrections to the TV2 Region streaming

### DIFF
--- a/channels.py
+++ b/channels.py
@@ -163,9 +163,9 @@ Channel(106, CATEGORY_TV2_REG).add_urls(
 )
 # TV2 OJ
 TV2RChannel(108, CATEGORY_TV2_REG).add_urls(
-    best   = 'rtmp://<HOST>:1935/live/_definst_/tv2oj_2000 live=1',
-    high   = 'rtmp://<HOST>:1935/live/_definst_/tv2oj_1000 live=1',
-    medium = 'rtmp://<HOST>:1935/live/_definst_/tv2oj_300 live=1'
+    best   = 'rtmp://<HOST>:1935/live/_definst_/tv2oj-plus_2000 live=1',
+    high   = 'rtmp://<HOST>:1935/live/_definst_/tv2oj_plus_1000 live=1',
+    medium = 'rtmp://<HOST>:1935/live/_definst_/tv2oj_plus_300 live=1'
 )
 # TV2 Bornholm
 Channel(109, CATEGORY_TV2_REG).add_urls(

--- a/channels.py
+++ b/channels.py
@@ -132,7 +132,9 @@ Channel(5, CATEGORY_DR, "drramasjang.stream").add_urls(
 
 # TV2 Fyn
 TV2RChannel(100, CATEGORY_TV2_REG).add_urls(
-    high   = 'rtmp://<HOST>:1935/live/_definst_/tv2fyn_1000 live=1'
+    best   = 'rtmp://<HOST>:1935/live/_definst_/tv2fyn_2000 live=1',
+    high   = 'rtmp://<HOST>:1935/live/_definst_/tv2fyn_1000 live=1',
+    medium = 'rtmp://<HOST>:1935/live/_definst_/tv2fyn_300 live=1'
 )
 # TV2 Lorry
 TV2RChannel(101, CATEGORY_TV2_REG).add_urls(

--- a/channels.py
+++ b/channels.py
@@ -90,7 +90,7 @@ class TV2RChannel(Channel):
     def get_host_ip(self):
         for attempt in range(0, 2):
             try:
-                u = urllib2.urlopen('http://livestream.fynskemedier.dk/loadbalancer')
+                u = urllib2.urlopen('http://livestream2.fynskemedier.dk/loadbalancer')
                 s = u.read()
                 u.close()
                 return s[9:]


### PR DESCRIPTION
The change in d8591b5 is pretty urgent, as the five TV2 Region sites that we provide streaming for switched to a different streaming server today. Streaming is broken until this is applied.

The two other changes changes the TV2/ØJ stream to point to their 24h channel and sets up multiple bitrates for TV2/Fyn.

René H. Larsen, Fynske Medier P/S
